### PR TITLE
Enable basic watching of geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,33 +59,6 @@ Bind to `position` to access all properties from [GeolocationPosition](https://d
 ```
 <!-- prettier-ignore-end -->
 
-### Watching Position
-
-Set `watch` to `true` to invoke the `geolocation.watchPosition` method and get informed if the user changes position.
-
-<!-- prettier-ignore-start -->
-```svelte
-<script>
-  let getPosition = false;
-  let positions = [];
-  
-  const handlePosition = (position) => {
-    if (!position) {
-      return
-    }
-
-    positions.push(position);
-    positions = positions;
-  }
-</script>
-
-<button type="button" on:click={() => (getPosition = !getPosition)}>Get Position</button>
-<Geolocation getPosition watch={true} on:position={(event) => handlePosition(event.detail.coords)} />
-
-<pre>{JSON.stringify(positions, null, 2)}</pre>
-```
-<!-- prettier-ignore-end -->
-
 ### Controlled trigger + default slot
 
 This example shows the controlled invocation of `geolocation.getCurrentPosition`.
@@ -130,6 +103,26 @@ Using the default slot, you can destructure the following props:
     {/if}
   {/if}
 </Geolocation>
+```
+<!-- prettier-ignore-end -->
+
+### Watching Position
+
+Set `watch` to `true` to invoke the `geolocation.watchPosition` method and get informed if the user changes position.
+
+<!-- prettier-ignore-start -->
+```svelte
+<script>
+  let getPositionAgain = false;
+  let detail = {};
+</script>
+
+<button type="button" on:click={() => (getPositionAgain = !getPositionAgain)}>Get Position</button>
+<Geolocation getPosition={getPositionAgain} watch={true} on:position={(e) => {
+  detail = e.detail
+  }} />
+
+<pre>{JSON.stringify(detail, null, 2)}</pre>
 ```
 <!-- prettier-ignore-end -->
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,33 @@ Bind to `position` to access all properties from [GeolocationPosition](https://d
 ```
 <!-- prettier-ignore-end -->
 
+### Watching Position
+
+Set `watch` to `true` to invoke the `geolocation.watchPosition` method and get informed if the user changes position.
+
+<!-- prettier-ignore-start -->
+```svelte
+<script>
+  let getPosition = false;
+  let positions = [];
+  
+  const handlePosition = (position) => {
+    if (!position) {
+      return
+    }
+
+    positions.push(position);
+    positions = positions;
+  }
+</script>
+
+<button type="button" on:click={() => (getPosition = !getPosition)}>Get Position</button>
+<Geolocation getPosition watch={true} on:position={(event) => handlePosition(event.detail.coords)} />
+
+<pre>{JSON.stringify(positions, null, 2)}</pre>
+```
+<!-- prettier-ignore-end -->
+
 ### Controlled trigger + default slot
 
 This example shows the controlled invocation of `geolocation.getCurrentPosition`.
@@ -186,6 +213,7 @@ Specify [Geolocation position options](https://developer.mozilla.org/en-US/docs/
 | position     | [GeolocationPosition](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition)                                        |
 | options      | [PositionOptions](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions)                                                |
 | getPosition  | `boolean` (default: `false`)                                                                                                       |
+| watch        | `boolean` (default: `false`)                                                                                                       |
 | loading      | `boolean` (default: `false`)                                                                                                       |
 | success      | `boolean` (default: `false`)                                                                                                       |
 | error        | `false` or [GeolocationPositionError](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError) (default:`false`) |

--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -37,7 +37,7 @@
   /** `true` if the browser does not support the Geolocation API */
   export let notSupported = false;
 
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, onDestroy } from 'svelte'
 
   const dispatch = createEventDispatcher();
 
@@ -79,7 +79,8 @@
     if (!("geolocation" in navigator)) {
       notSupported = true;
     } else {
-      return watcherId ? watcherId : navigator.geolocation.watchPosition(handlePosition, handleError, opts);
+      watcherId = watcherId ? watcherId : navigator.geolocation.watchPosition(handlePosition, handleError, opts);
+      return watcherId;
     }
   }
 
@@ -102,6 +103,10 @@
       navigator.geolocation.clearWatch(watcherId);
     }
   }
+
+  onDestroy(() => {
+    if (watcherId) clearWatcher(watcherId)
+  });
 
   $: success = !loading && !error;
 </script>

--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -22,6 +22,15 @@
   /** @type {Partial<GeolocationPosition>} */
   export let position = {};
 
+  /** @type {PositionOptions} */
+  export let options = {};
+
+  /** Set to `true` to enable `geolocation` API. If `watch` is false, then `geolocation.getCurrentLocation` is used. */
+  export let getPosition = false;
+
+  /** Set to `true` to enable `geolocation.watchPosition` */
+  export let watch = false;
+
   /** `true` when the position is being fetched */
   export let loading = false;
 
@@ -84,7 +93,7 @@
     }
   }
 
-  export async function getPosition(opts) {
+  export async function getGeolocationPosition(opts) {
     notSupported = false;
     loading = true;
     error = false;
@@ -108,7 +117,10 @@
     if (watcherId) clearWatcher(watcherId)
   });
 
-  $: success = !loading && !error;
+  $: if (getPosition && watch) watchPosition(options);
+  $: if (getPosition && !watch) getGeolocationPosition(options);
+  $: success = getPosition && !loading && !error;
+  $: if ((!getPosition || !watch) && watcherId) clearWatcher(watcherId);
 </script>
 
 <slot loading="{loading}" success="{success}" error="{error}" notSupported="{notSupported}" coords="{coords}" />

--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -46,12 +46,13 @@
   /** `true` if the browser does not support the Geolocation API */
   export let notSupported = false;
 
-  import { createEventDispatcher, onDestroy } from 'svelte'
+  import { createEventDispatcher, onDestroy } from "svelte";
 
   const dispatch = createEventDispatcher();
 
   let watcherId = undefined;
   let lastPosition = undefined;
+
   function handlePosition(pos) {
     coords = [pos.coords.longitude, pos.coords.latitude];
     position = {

--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -22,15 +22,6 @@
   /** @type {Partial<GeolocationPosition>} */
   export let position = {};
 
-  /** @type {PositionOptions} */
-  export let options = {};
-
-  /** Set to `true` to invoke `geolocation.getCurrentPosition` */
-  export let getPosition = false;
-
-  /** Set to `true` to enable `geolocation.watchPosition` */
-  export let watch = false;
-
   /** `true` when the position is being fetched */
   export let loading = false;
 
@@ -80,21 +71,31 @@
     loading = false;
   }
 
-  async function getGeolocationPosition(opts) {
+  export async function watchPosition(opts) {
     notSupported = false;
     loading = true;
     error = false;
 
     if (!("geolocation" in navigator)) {
       notSupported = true;
-    } else if (watch) {
-      watcherId = watcherId ? watcherId : navigator.geolocation.watchPosition(handlePosition, handleError, opts);
+    } else {
+      return watcherId ? watcherId : navigator.geolocation.watchPosition(handlePosition, handleError, opts);
+    }
+  }
+
+  export async function getPosition(opts) {
+    notSupported = false;
+    loading = true;
+    error = false;
+
+    if (!("geolocation" in navigator)) {
+      notSupported = true;
     } else {
       navigator.geolocation.getCurrentPosition(handlePosition, handleError, opts);
     }
   }
 
-  async function clearWatcher(watcherId) {
+  export async function clearWatcher(watcherId) {
     if (!("geolocation" in navigator)) {
       notSupported = true;
     } else {
@@ -102,9 +103,7 @@
     }
   }
 
-  $: if (getPosition) getGeolocationPosition(options);
-  $: success = getPosition && !loading && !error;
-  $: if (!watch && watcherId) clearWatcher(watcherId);
+  $: success = !loading && !error;
 </script>
 
 <slot loading="{loading}" success="{success}" error="{error}" notSupported="{notSupported}" coords="{coords}" />

--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -70,7 +70,11 @@
       timestamp: pos.timestamp,
     };
 
-    if (!lastPosition || (lastPosition.coords.latitude !== pos.coords.latitude || lastPosition.coords.longitude !== pos.coords.longitude)) {
+    if (
+      !lastPosition ||
+      lastPosition.coords.latitude !== pos.coords.latitude ||
+      lastPosition.coords.longitude !== pos.coords.longitude
+    ) {
       lastPosition = pos;
       dispatch("position", position);
     }
@@ -91,7 +95,13 @@
     if (!("geolocation" in navigator)) {
       notSupported = true;
     } else {
-      watcherId = watcherId ? watcherId : navigator.geolocation.watchPosition(handlePosition, handleError, opts);
+      watcherId = watcherId
+        ? watcherId
+        : navigator.geolocation.watchPosition(
+            handlePosition,
+            handleError,
+            opts
+          );
       return watcherId;
     }
   }
@@ -104,7 +114,11 @@
     if (!("geolocation" in navigator)) {
       notSupported = true;
     } else {
-      navigator.geolocation.getCurrentPosition(handlePosition, handleError, opts);
+      navigator.geolocation.getCurrentPosition(
+        handlePosition,
+        handleError,
+        opts
+      );
     }
   }
 
@@ -117,7 +131,7 @@
   }
 
   onDestroy(() => {
-    if (watcherId) clearWatcher(watcherId)
+    if (watcherId) clearWatcher(watcherId);
   });
 
   $: if (getPosition && watch) watchPosition(options);
@@ -126,4 +140,10 @@
   $: if ((!getPosition || !watch) && watcherId) clearWatcher(watcherId);
 </script>
 
-<slot loading="{loading}" success="{success}" error="{error}" notSupported="{notSupported}" coords="{coords}" />
+<slot
+  loading="{loading}"
+  success="{success}"
+  error="{error}"
+  notSupported="{notSupported}"
+  coords="{coords}"
+/>

--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -50,7 +50,9 @@
 
   const dispatch = createEventDispatcher();
 
+  /** @type {Number | undefined} */
   let watcherId = undefined;
+  /** @type {GeolocationPosition | undefined} */
   let lastPosition = undefined;
 
   function handlePosition(pos) {

--- a/test.svelte
+++ b/test.svelte
@@ -19,7 +19,14 @@
 
 <Geolocation getPosition="{getPosition}" bind:position />
 
-<Geolocation getPosition="{getPosition}" bind:coords let:loading let:success let:error let:notSupported>
+<Geolocation
+  getPosition="{getPosition}"
+  bind:coords
+  let:loading
+  let:success
+  let:error
+  let:notSupported
+>
   {#if notSupported}
     Your browser does not support the Geolocation API.
   {:else}
@@ -37,9 +44,9 @@
 >Get geolocation</button>
 
 <Geolocation
-  bind:this={ref}
+  bind:this="{ref}"
   getPosition
-  watch={false}
+  watch="{false}"
   on:position="{(e) => {
     console.log(e.detail); // GeolocationPosition
   }}"

--- a/test.svelte
+++ b/test.svelte
@@ -2,6 +2,7 @@
   import Geolocation from "./types";
   import { GeolocationCoords } from "./types/Geolocation";
 
+  let ref: Geolocation;
   let getPosition = false;
   let position = {};
   let coords: GeolocationCoords = [-1, -1];
@@ -11,6 +12,9 @@
     timeout: 5000, // milliseconds
     maximumAge: 60 * 60 * 1000, // milliseconds
   };
+
+  $: if (ref) ref.getGeolocationPosition();
+  $: if (ref) ref.watchPosition();
 </script>
 
 <Geolocation getPosition="{getPosition}" bind:position />
@@ -33,7 +37,9 @@
 >Get geolocation</button>
 
 <Geolocation
+  bind:this={ref}
   getPosition
+  watch={false}
   on:position="{(e) => {
     console.log(e.detail); // GeolocationPosition
   }}"

--- a/types/Geolocation.d.ts
+++ b/types/Geolocation.d.ts
@@ -23,10 +23,16 @@ export interface GeolocationProps {
   options?: PositionOptions;
 
   /**
-   * Set to `true` to invoke `geolocation.getCurrentPosition`
+   * Set to `true` to enable `geolocation` API. If `watch`
+   * is false, then `geolocation.getCurrentLocation` is used.
    * @default false
    */
   getPosition?: boolean;
+
+  /** Set to `true` to enable `geolocation.watchPosition`
+   * @default false
+   */
+  watch?: boolean;
 
   /**
    * `true` when the position is being fetched


### PR DESCRIPTION
Hi there, this is a draft for implementing `geolocation.watchPosition()`.

This is not yet complete, as this has several flaws:
- [x] The `watch` prop is not fully reactive, as `getPosition` has to be toggled to reenable watching position.
- [x] Not documented yet
- [x] clear watcher on destroy

And generally speaking: having two booleans that trigger the geolocation API feels odd. But I am not sure what the best way is to solve this. Could be by giving `getPosition` more meaning (making it a String).
Another idea (not sure if that would work) is to provide a slot for the getPosition-Button, and another one for the watch-Button and listen to the click event (like [here](https://github.com/sveltejs/sapper/issues/731#issuecomment-500487405)).. But I think this would be a dirty solution..

WDYT?