### PR TITLE
Fix watching hangs in loading state

### DIFF
--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -95,13 +95,10 @@
     if (!("geolocation" in navigator)) {
       notSupported = true;
     } else {
-      watcherId = watcherId
-        ? watcherId
-        : navigator.geolocation.watchPosition(
-            handlePosition,
-            handleError,
-            opts
-          );
+      if (watcherId) {
+        await clearWatcher(watcherId);
+      }
+      watcherId = navigator.geolocation.watchPosition(handlePosition, handleError, opts);
       return watcherId;
     }
   }
@@ -127,6 +124,7 @@
       notSupported = true;
     } else {
       navigator.geolocation.clearWatch(watcherId);
+      watcherId = undefined;
     }
   }
 


### PR DESCRIPTION
This would happen, if the watch property was toggled more than one time, because the watcherId was never resetted and the next watchPosition call would just return the stale watcherId.

A bit strange is that I have to call `clearWatcher()` from inside `watchPosition()`. It is not sufficient to just reset `watcherId` State in `clearWatcher()`. I tried to fix that by waiting for the next tick, but that didn't help. So I went with calling it every time when `watchPosition()` is executed.