### PR TITLE
Guard against window is undefined to support SSR

### DIFF
--- a/src/Geolocation.svelte
+++ b/src/Geolocation.svelte
@@ -154,8 +154,10 @@
     if (watcherId) clearWatcher(watcherId);
   });
 
-  $: if (getPosition && watch) watchPosition(options);
-  $: if (getPosition && !watch) getGeolocationPosition(options);
+  $: if (typeof window !== "undefined" && getPosition && watch)
+    watchPosition(options);
+  $: if (typeof window !== "undefined" && getPosition && !watch)
+    getGeolocationPosition(options);
   $: success = getPosition && !loading && !error;
   $: if ((!getPosition || !watch) && watcherId) clearWatcher(watcherId);
 </script>


### PR DESCRIPTION
#4

**Fixes**

- guard against `window` is undefined to support SSR environments, like SvelteKit